### PR TITLE
Update auto HB selection to use correct rates 

### DIFF
--- a/cook_input.m
+++ b/cook_input.m
@@ -220,16 +220,26 @@ end
 
 if dec_int3 || (~isfield(input, 'FIR') && ~isfield(input, 'HB1') && ~isfield(input, 'HB2') && ~isfield(input, 'HB3') && ~isfield(input, 'PLL_mult'))
     % Everything is blank, run as fast as possible
+    input.FIR = fastest_FIR([4 2 1], bounds9361.MAX_FIR, 0, input.Rdata);
+    input.HB1 = fastest_FIR([2 1], max_HB.HB1, 0, input.Rdata * input.FIR);
+    input.HB2 = fastest_FIR([2 1], max_HB.HB2, 0, input.Rdata * input.FIR * input.HB1 );
     if dec_int3
-        input.HB3 = fastest_FIR([3 2 1], max_HB.HB3, 0, input.Rdata);
+        input.HB3 = fastest_FIR([3 2 1], max_HB.HB3, 0, input.Rdata * input.FIR * input.HB1 * input.HB2);
     else
-        input.HB3 = fastest_FIR([2 1], max_HB.HB3, 0, input.Rdata);
+        input.HB3 = fastest_FIR([2 1], max_HB.HB3, 0, input.Rdata * input.FIR * input.HB1 * input.HB2);
     end
-    input.HB2 = fastest_FIR([2 1], max_HB.HB2, 0, input.Rdata * input.HB3);
-    input.HB1 = fastest_FIR([2 1], max_HB.HB1, 0, input.Rdata * input.HB3 * input.HB2);
-    input.FIR = fastest_FIR([4 2 1], bounds9361.MAX_FIR, 0, input.Rdata * input.HB3 * input.HB2 * input.HB1);
     input.PLL_mult = fastest_FIR([64 32 16 8 4 2 1], bounds9361.MAX_BBPLL_FREQ, bounds9361.MIN_BBPLL_FREQ, input.Rdata * input.FIR * input.HB1 * input.HB2 * input.HB3 * input.DAC_div);
 end
 
 input.converter_rate = input.Rdata * input.FIR * input.HB1 * input.HB2 * input.HB3;
 input.PLL_rate = input.converter_rate * input.DAC_div * input.PLL_mult;
+
+if strcmp(input.RxTx, 'Rx')
+    if input.converter_rate > bounds9361.MAX_ADC_CLK || input.converter_rate < bounds9361.MIN_ADC_CLK
+        error('Invalid ADC Rate');
+    end
+else
+    if input.converter_rate > bounds9361.MAX_DAC_CLK || input.converter_rate < bounds9361.MIN_DAC_CLK
+        error('Invalid DAC Rate');
+    end
+end


### PR DESCRIPTION
This PR updates the autoselect_rates function within cook_input to use the correct MIN/MAX rates when determining decimation/interpolation settings. Previously checks were invalid and minimal rates would end up selected based on the input data rate.

Brute force testing 520 kHz to 61.44 MHz input rates have created valid configurations.

Signed-off-by: Travis Collins <travis.collins@analog.com>