### PR TITLE
Fix Tx tap length calculation

### DIFF
--- a/internal_design_filter.m
+++ b/internal_design_filter.m
@@ -422,7 +422,7 @@ else
         case 4
             Nmax = 128;
     end
-    N = min(16*floor(input.converter_rate*input.DAC_div/(2*input.Rdata)),Nmax);
+    N = min(16*floor(input.converter_rate/(input.Rdata)),Nmax);
 end
 
 tap_store = zeros(N/16,N);


### PR DESCRIPTION
Tx converter_rate value was double-counting dac_div resulting in less
taps than actually available.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>